### PR TITLE
Remove obsolete AZUREJOBS_EXTENSION_VERSION App Setting

### DIFF
--- a/deploy/templates/quizapp-function.json
+++ b/deploy/templates/quizapp-function.json
@@ -48,8 +48,7 @@
                     "properties": {
                         "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]", 
                         "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]", 
-                        "FUNCTIONS_EXTENSION_VERSION": "latest",
-                        "AZUREJOBS_EXTENSION_VERSION": "beta"
+                        "FUNCTIONS_EXTENSION_VERSION": "latest"
                     }
                 }               
             ]


### PR DESCRIPTION
This setting is no longer needed and should be removed. It could cause issues going forward.